### PR TITLE
chore: document Cursor Cloud dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test-build/
 *.log
 __pycache__/
 .pytest_cache/
+.venv-backend/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+House Plan is one HACS package with two parts plus a demo harness:
+
+- **Lovelace card** (`src/`, TypeScript + Lit) — the primary product, bundled to `dist/houseplan-card.js`.
+- **Storage integration** (`custom_components/houseplan/`, Python) — the Home Assistant backend.
+- **Demo harness** (`demo/`) — a self-contained Playwright page (`demo/srv/demo.html`) that renders the card against a fake `hass`, used for screenshots and the `smoke_*.mjs` end-to-end suite.
+
+Standard commands live in `package.json` scripts, `CONTRIBUTING.md`, and `docs/DEVELOPMENT.md`. Read `docs/ARCHITECTURE.md` and `docs/STATUS.md` before non-trivial changes.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `npm ci`, provisions a Python 3.13 backend venv at `.venv-backend`, and installs Playwright Chromium. You do not need to reinstall dependencies.
+
+- **Frontend** (from repo root): `npm run typecheck`, `npm test` (node:test, ~270 tests), `npm run build`. After building, keep the integration copy in sync — `cp dist/houseplan-card.js custom_components/houseplan/frontend/`. CI enforces `cmp dist/houseplan-card.js custom_components/houseplan/frontend/houseplan-card.js` byte-for-byte.
+- **Backend HA-harness tests need Python 3.13, not the system 3.12.** Run them with the venv: `.venv-backend/bin/python -m pytest tests_backend/ -q` (126 tests). Running `python3 -m pytest tests_backend` on the system 3.12 silently **skips** the `test_ha_*.py` harness tests (`conftest.py` ignores them when `homeassistant` is not importable) and runs only the ~83 pure tests.
+- **Running the app / smoke suite**: build a fresh bundle and copy it into the demo assets first — `npm run build && cp dist/houseplan-card.js demo/srv/assets/houseplan-card.js` — then run `node demo/smoke_*.mjs`. The committed `demo/srv/assets/houseplan-card.js` is a stale snapshot; testing it reports green about code that no longer exists. No real Home Assistant server is required: `demo/srv/demo.html` stubs `hass`, registries and `callService`.
+- **Demo harness render quirk**: the fake `hass` in `demo.html` is set once, so opening the page directly in a browser renders the floor plan but **device icons only appear after a re-render** (an F5 refresh, or nudging `card.hass = {...card.hass}`). The smoke launcher `demo/serve.mjs` already does this nudge; a plain browser session does not. This is a harness limitation, not a card bug.
+- **Known environment-sensitive smoke**: `demo/smoke_opening_measure.mjs` fails two sub-checks (`place_dialog_x_magnetised`, `place_committed_x_center`) under the pinned Chromium — a `1e-6`-tolerance magnet-snap on the opening-*placement* path. It reproduces against the pristine committed bundle, so treat it as pre-existing/pixel-precision, not a regression you introduced.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents the development environment for this HACS package (Lovelace card + Home Assistant integration + Playwright demo harness). No product code changed.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious setup/run caveats.
- Adds `.venv-backend/` to `.gitignore` (the Python 3.13 venv the startup update script provisions for the HA-harness backend tests).

## Environment verified

| Component | Command | Result |
| --- | --- | --- |
| Frontend typecheck | `npm run typecheck` | pass |
| Frontend unit tests | `npm test` | 270 passed |
| Frontend build + sync | `npm run build` + `cmp` vs integration copy | built, byte-identical |
| Backend (pure + HA harness) | `.venv-backend/bin/python -m pytest tests_backend -q` | 126 passed (Python 3.13) |
| App / smoke suite | `node demo/smoke_*.mjs` (fresh bundle) | 99/100 pass |

The single smoke failure (`demo/smoke_opening_measure.mjs`, two `1e-6`-tolerance magnet-snap sub-checks on the opening-placement path) reproduces against the pristine committed bundle, so it is pre-existing / pixel-precision under the pinned Chromium — not introduced here. Documented in `AGENTS.md`.

## Hello-world demo

Rendered the card in a real browser via the demo harness and toggled the Living Room ceiling light (on → off → on), confirming interactive device control works end-to-end.

[Rendered House Plan card with device states](https://cursor.com/agents/bc-75af4714-9c26-4a63-9af3-0dbf0e386009/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhouseplan_card_rendered.png)

[houseplan_card_toggle_light_demo.mp4](https://cursor.com/agents/bc-75af4714-9c26-4a63-9af3-0dbf0e386009/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhouseplan_card_toggle_light_demo.mp4)

## Startup update script (proposed)

```
npm ci
pip install --break-system-packages -q uv
test -d .venv-backend || python3 -m uv venv --python 3.13 .venv-backend
python3 -m uv pip install --python .venv-backend/bin/python pytest voluptuous pytest-homeassistant-custom-component home-assistant-frontend
npx playwright install --with-deps chromium
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75af4714-9c26-4a63-9af3-0dbf0e386009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75af4714-9c26-4a63-9af3-0dbf0e386009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

